### PR TITLE
Point selection

### DIFF
--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -1,4 +1,5 @@
 # TODO: only import necessary functions from libraries
+from operator import ne
 import numpy as np
 import ast
 import matplotlib.pyplot as plt
@@ -147,7 +148,7 @@ if __name__ == "__main__":
     # run fasterPAM to get all neighbourhoods
     start_time = time.time()
     logger.debug(f"Starting fasterPAM at {start_time}")
-    pam_result = kmedoids.fasterpam(dissimilarities, 5)
+    pam_result = kmedoids.fasterpam(dissimilarities, 5, random_state=42)
     logger.debug(f"FasterPAM took {time.time() - start_time} seconds")
 
     logger.info(f"Medoids: {pam_result.medoids}")
@@ -156,9 +157,6 @@ if __name__ == "__main__":
     # Map medoid indices back to original coordinates
     medoid_coords = reachable_coordinates[pam_result.medoids]
     
-    logger.debug(f"cluster result size {pam_result.labels.shape} vs reachable size {reachable_coordinates.shape}")
-    logger.debug(f"label: {pam_result.labels[0]}, coord: {reachable_coordinates[0]}")
-
     # re-map to array for visualization
     cluster_map = np.full(reachable.shape, -1)
     for i, coord in enumerate(reachable_coordinates):
@@ -169,7 +167,16 @@ if __name__ == "__main__":
     plt.colorbar()
     plt.gca().invert_yaxis()
     plt.scatter(origin[0], origin[1], color='red')
+    plt.scatter(medoid_coords[:, 1], medoid_coords[:, 0], color='black')
     plt.show()
+
+    # organize the data into neighbourhoods
+    neighbourhoods = []
+    for i in range(5):
+        cur_neighbourhood = np.argwhere(cluster_map == i)  
+        neighbourhoods.append(cur_neighbourhood)
+
+        logger.debug(f"neighbourhood {i} has  {cur_neighbourhood.shape} points")
 
     # for each neighbourhood, find 5 additional points as far away from one another as possible
     # POTENTIAL ISSUE: are points all going to be on the border of the neighbourhood?

--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -20,12 +20,6 @@ logger = logging.getLogger("point selection")
 logger.setLevel(logging.DEBUG)
 logger.debug("Logging initialized")
 
-def get_random_colors(num_colors):
-    colors = []
-    for _ in range(num_colors):
-        colors.append("#" + ''.join([random.choice('0123456789ABCDEF') for _ in range(6)]))
-    return colors
-
 def get_points_in_neighbourhood(points: np.ndarray, num_points: int, medoid: tuple) -> np.ndarray:
     selected_points = [medoid]
     remaining_points = [p for p in points if p != medoid]
@@ -206,9 +200,10 @@ if __name__ == "__main__":
 
         logger.debug(f"neighbourhood {i} has  {len(cur_neighbourhood)} points")
 
+    all_neighbourhoods = np.argwhere(cluster_map != -1)
+    all_neighbourhoods = [tuple(x) for x in all_neighbourhoods]
+
     # for each neighbourhood, find 5 additional points as far away from one another as possible
-    # POTENTIAL ISSUE: are points all going to be on the border of the neighbourhood?
-    # maybe add padding around the border to prevent this?
     neighbourhood_points = []
     for i in range(5):
         # convert to tuples first
@@ -218,13 +213,13 @@ if __name__ == "__main__":
         neighbourhood_points.append(get_points_in_neighbourhood(cur_neighbourhood, 5, medoid))
 
     # display on graph
-    plt.imshow(reachable, cmap='gray_r', interpolation='nearest')
+    plt.imshow(cluster_map, cmap='Pastel1', interpolation='nearest')
     plt.colorbar()
     plt.gca().invert_yaxis()
     plt.scatter(origin[0], origin[1], color='red')
-    plt.scatter(medoid_coords[:, 1], medoid_coords[:, 0], color='black')
-    colours = get_random_colors(5)
+    colours = ['steelblue', 'darkslateblue', 'darkgoldenrod', 'darkmagenta', 'slategrey']
     for i in range(5):
         plt.scatter(neighbourhood_points[i][:, 1], neighbourhood_points[i][:, 0], color=colours[i])
+    plt.scatter(medoid_coords[:, 1], medoid_coords[:, 0], color='black')
     plt.show()
 

--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -3,6 +3,50 @@ import numpy as np
 import ast
 import matplotlib.pyplot as plt
 import logging
+from collections import deque
+import time
+
+# set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("point selection")
+logger.setLevel(logging.DEBUG)
+logger.debug("Logging initialized")
+
+def bfs(data: np.ndarray, start: tuple) -> np.ndarray:
+    # initialize values
+    visited = np.zeros(data.shape, dtype=bool)
+    stack = deque()
+
+    # add start to stack
+    stack.append(start)
+
+    # while stack is not empty
+    while stack:
+        visited[start] = True
+        stack.pop()
+
+def find_room_size(data: np.ndarray) -> tuple:
+    # find the farthest 1 in each direction
+
+    min_x = data.shape[0]
+    max_x = 0
+    min_y = data.shape[1]
+    max_y = 0
+
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            if data[i, j] == 1:
+                if i < min_x:
+                    min_x = i
+                if i > max_x:
+                    max_x = i
+                if j < min_y:
+                    min_y = j
+                if j > max_y:
+                    max_y = j
+
+    # bottom left & top right corners
+    return (min_x, min_y), (max_x, max_y)  
 
 if __name__ == "__main__":
     # load in data from testData
@@ -14,19 +58,31 @@ if __name__ == "__main__":
     
     # Convert the list to a numpy array
     sample_data = np.array(sample_data)
+    origin = (sample_data.shape[0] // 2, sample_data.shape[1] // 2) # origin based on measurements from Aleks
+    # origin = (97, 84) # origin based on where Aleks said it was
     
-    print(sample_data.shape)
+    logger.debug(f"Loaded data with shape {sample_data.shape}")
+    logger.debug(f"Origin: {origin}")
 
     # display on graph
     plt.imshow(sample_data, cmap='grey_r', interpolation='nearest')
     plt.colorbar()
+    plt.gca().invert_yaxis()
+    plt.scatter(origin[0], origin[1], color='red')
+
     plt.show()
 
     # find room size
+    logger.debug(f"Starting to find room size at {time.time()}")
+    bottom_left, top_right = find_room_size(sample_data)
+    logger.debug(f"Room size found at {time.time()}")
+    logger.debug(f"Bottom left: {bottom_left}")
+    logger.debug(f"Top right: {top_right}")
 
-    # add border
+    # add border of 1s around the room
+    # may not need to do this if not using jps
 
-    # find all reachable nodes
+    # find all reachable nodes using bfs
 
     # run fasterPAM to get all neighbourhoods
 

--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -1,4 +1,6 @@
 # TODO: only import necessary functions from libraries
+from turtle import left
+from matplotlib.pylab import f
 import numpy as np
 import ast
 import matplotlib.pyplot as plt
@@ -28,25 +30,39 @@ def bfs(data: np.ndarray, start: tuple) -> np.ndarray:
 def find_room_size(data: np.ndarray) -> tuple:
     # find the farthest 1 in each direction
 
-    min_x = data.shape[0]
+    min_x = data.shape[1]
     max_x = 0
-    min_y = data.shape[1]
+    min_y = data.shape[0]
     max_y = 0
 
     for i in range(data.shape[0]):
         for j in range(data.shape[1]):
             if data[i, j] == 1:
-                if i < min_x:
-                    min_x = i
-                if i > max_x:
-                    max_x = i
-                if j < min_y:
-                    min_y = j
-                if j > max_y:
-                    max_y = j
+                if i < min_y:
+                    min_y = i
+                if i > max_y:
+                    max_y = i
+                if j < min_x:
+                    min_x = j
+                if j > max_x:
+                    max_x = j
 
     # bottom left & top right corners
     return (min_x, min_y), (max_x, max_y)  
+
+def trim_and_border_data(data: np.ndarray, bottom_left: tuple, top_right: tuple) -> np.ndarray:
+    # trim data to only include the room
+    right_edge = np.min([data.shape[1], top_right[0]])
+    top_edge = np.min([data.shape[0], top_right[1]])
+    left_edge = np.max([0, bottom_left[0]])
+    bottom_edge = np.max([0, bottom_left[1]])
+
+    trimmed_data = data[bottom_edge:top_edge+1, left_edge:right_edge+1]
+
+    # add border of 1s around the room
+    trimmed_data = np.pad(trimmed_data, 1, constant_values=1)
+
+    return trimmed_data
 
 if __name__ == "__main__":
     # load in data from testData
@@ -64,14 +80,6 @@ if __name__ == "__main__":
     logger.debug(f"Loaded data with shape {sample_data.shape}")
     logger.debug(f"Origin: {origin}")
 
-    # display on graph
-    plt.imshow(sample_data, cmap='grey_r', interpolation='nearest')
-    plt.colorbar()
-    plt.gca().invert_yaxis()
-    plt.scatter(origin[0], origin[1], color='red')
-
-    plt.show()
-
     # find room size
     logger.debug(f"Starting to find room size at {time.time()}")
     bottom_left, top_right = find_room_size(sample_data)
@@ -79,8 +87,21 @@ if __name__ == "__main__":
     logger.debug(f"Bottom left: {bottom_left}")
     logger.debug(f"Top right: {top_right}")
 
+
+    # adjust origin based on room size
+    # +1 is needed due to the added padding
+    origin = (origin[0] - bottom_left[0]+1, origin[1] - bottom_left[1]+1)
+    logger.debug(f"Adjusted origin: {origin}")
+
     # add border of 1s around the room
-    # may not need to do this if not using jps
+    trimmed_data = trim_and_border_data(sample_data, bottom_left, top_right)
+
+    # display on graph
+    plt.imshow(trimmed_data, cmap='grey_r', interpolation='nearest')
+    plt.colorbar()
+    plt.gca().invert_yaxis()
+    plt.scatter(origin[0], origin[1], color='red')
+    plt.show()
 
     # find all reachable nodes using bfs
 

--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -360,6 +360,16 @@ if __name__ == "__main__":
     
     # Convert the string representation of the list to an actual list
     sample_data = literal_eval(data_str)
+
+    # TODO: make sure this works properly with data from shared memory
+    # rotate data 90 degress ccw & mirror over y-axis
+    sample_data = np.array(sample_data).T
+
+    plt.imshow(sample_data, cmap='grey_r', interpolation='nearest')
+    plt.colorbar()
+    plt.gca().invert_yaxis()
+    plt.scatter(88, 88, color='red')
+    plt.show()
     
     # Convert the list to a numpy array
     sample_data = np.array(sample_data)

--- a/LiDAR/examples/point_selection.py
+++ b/LiDAR/examples/point_selection.py
@@ -1,0 +1,35 @@
+# TODO: only import necessary functions from libraries
+import numpy as np
+import ast
+import matplotlib.pyplot as plt
+import logging
+
+if __name__ == "__main__":
+    # load in data from testData
+    with open('testData', 'r') as file:
+        data_str = file.read()
+    
+    # Convert the string representation of the list to an actual list
+    sample_data = ast.literal_eval(data_str)
+    
+    # Convert the list to a numpy array
+    sample_data = np.array(sample_data)
+    
+    print(sample_data.shape)
+
+    # display on graph
+    plt.imshow(sample_data, cmap='grey_r', interpolation='nearest')
+    plt.colorbar()
+    plt.show()
+
+    # find room size
+
+    # add border
+
+    # find all reachable nodes
+
+    # run fasterPAM to get all neighbourhoods
+
+    # for each neighbourhood, find 5 additional points as far away from one another as possible
+    # POTENTIAL ISSUE: are points all going to be on the border of the neighbourhood?
+    # maybe add padding around the border to prevent this?


### PR DESCRIPTION
Implemented point selection. Takes an occupancy grid and finds neighbourhoods and points within them

**General Process**

1.  Find the size of the room. The occupancy grid is much larger than the room, so find the edge of obstacles.
2. Add a border around the room
3. Find all reachable points using a modified breadth-first search
4. Run [FasterPAM](https://pypi.org/project/kmedoids/) on the reachable coordinates to get neighbourhoods
5. Find points as far away from one another in each neighbourhood

**Result**
Below is a graph of the result. Obstacles are shown in red. Each neighbourhoods is shown as a different colour. The selected points in the neighbourhood are shown as darker corresponding colours. The black points show the medoids calculated by FasterPAM. Finally, the origin is shown as the red point. 
![clusters w points - better](https://github.com/user-attachments/assets/8477f4dd-84f8-4f7e-bfa1-5553f374d2d4)

**Example** 
The below code is also found in the main function of point_selection.py. It has the code to process the occupancy grid found in testData
```python
    # load in data from testData
    with open('testData', 'r') as file:
        data_str = file.read()
    
    # Convert the string representation of the list to an actual list
    sample_data = literal_eval(data_str)
    
    # Convert the list to a numpy array
    sample_data = np.array(sample_data)
    origin = (sample_data.shape[0] // 2, sample_data.shape[1] // 2) # origin based on measurements from Aleks
    # origin = (97, 84) # origin based on where Aleks said it was in our call

    selected_points = occupancy_grid_to_points(sample_data, origin, plot_result=True)
```
